### PR TITLE
media:thumbnail

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,12 +3,15 @@
 """ fixtures """
 
 import pytest
+import PyMediaRSS2Gen as mrss
+
+FEED_URL = 'http://nowhere.org/rss.xml'
 
 @pytest.fixture
 def feed():
     """ fixture creating an empty feed """
     return mrss.MediaRSS2(
         title = 'Test Feed',
-        link = 'https://github.com/wedi/PyMediaRSS2Gen/',
+        link = 'http://nowhere.org/nopost',
         description = 'A testing feed'
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+
+""" fixtures """
+
+import pytest
+
+@pytest.fixture
+def feed():
+    """ fixture creating an empty feed """
+    return mrss.MediaRSS2(
+        title = 'Test Feed',
+        link = 'https://github.com/wedi/PyMediaRSS2Gen/',
+        description = 'A testing feed'
+    )

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+
+"""
+tests of MediaContent
+"""
+
+import pytest
+import PyMediaRSS2Gen as mrss
+
+from fixtures import *
+
+class TestMediaContent(object):
+
+    def test_output(self, feed):
+        """ output of a basic content should look like this """
+
+        image = mrss.MediaContent(
+            type='image',
+            url='http://nowhere.org/img/hippo.jpg',
+        )
+        item = mrss.MediaRSSItem(
+            title="Item with thumbnail",
+            media_content=image
+        )
+        feed.items = [item]
+        output = feed.to_xml()
+
+        assert output.endswith(
+            '<media:content url="http://nowhere.org/img/hippo.jpg" type="image"></media:content>'+
+            '</item></channel></rss>'
+        )

--- a/tests/test_mediarss2.py
+++ b/tests/test_mediarss2.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+
+"""
+tests of the main class -
+MediaRSS2
+"""
+
+import pytest
+import PyMediaRSS2Gen as mrss
+
+import fixtures
+
+class Test_EmptyFeed(object):
+
+    def test_toXML(self, feed):
+        """ it is possible to render an empty feed """
+        output = feed.to_xml()
+        assert output.startswith('<?xml')
+        assert '</channel>' in output
+        assert '<item>' not in output
+
+    @pytest.mark.xfail(reason='PyRSS2Gen ignores the attribute')
+    def test_hasNamespace(self, feed):
+        """ the feed defines the media module namespace """
+        output = feed.to_xml()
+        print output
+        assert 'xmlns:media="http://search.yahoo.com/mrss/"' in output
+
+class Test_Items(object):
+
+    def test_noMedia(self, feed):
+        """
+        it is possible to have an item without media content
+        in a media-enabled feed
+
+        The test simply shouldn't throw an error
+        """
+        feed.items = [
+            mrss.MediaRSSItem(
+                title="Item without media content",
+                description="It has no media content",
+            )
+        ]
+        output = feed.to_xml()

--- a/tests/test_mediarss2.py
+++ b/tests/test_mediarss2.py
@@ -8,7 +8,7 @@ MediaRSS2
 import pytest
 import PyMediaRSS2Gen as mrss
 
-import fixtures
+from fixtures import *
 
 class Test_EmptyFeed(object):
 
@@ -23,7 +23,6 @@ class Test_EmptyFeed(object):
     def test_hasNamespace(self, feed):
         """ the feed defines the media module namespace """
         output = feed.to_xml()
-        print output
         assert 'xmlns:media="http://search.yahoo.com/mrss/"' in output
 
 class Test_Items(object):

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+
+"""
+tests of MediaThumbnail
+"""
+
+import pytest
+import PyMediaRSS2Gen as mrss
+
+from fixtures import *
+
+@pytest.fixture
+def itemWithThumbnail():
+    """ fixture creating an item with thumbnail """
+    thumb = mrss.MediaThumbnail(
+        url='http://nowhere.org/img/hippo_tn.jpg',
+        time='00:15:46',
+        width=150,
+        height=652
+    )
+    image = mrss.MediaContent(
+        type='image',
+        url='http://nowhere.org/img/hippo.jpg',
+        media_thumbnails=thumb
+    )
+    return mrss.MediaRSSItem(
+        title="Item with thumbnail",
+        media_content=image
+    )
+
+class TestMediaThumbnail(object):
+
+    def test_withoutUrl(self):
+        """ url is required """
+        with pytest.raises(AttributeError):
+            mrss.MediaThumbnail(url=None)
+
+    def test_withoutTime(self):
+        """ is ok """
+        mrss.MediaThumbnail(url=FEED_URL)
+
+    def test_withInvalidTime(self):
+        """ time must be in the NTP format """
+        with pytest.raises(AttributeError):
+            mrss.MediaThumbnail(url=FEED_URL, time='notime')
+
+    def test_withValidTime(self):
+        """ is ok """
+        mrss.MediaThumbnail(url=FEED_URL, time='00:05:10')
+        mrss.MediaThumbnail(url=FEED_URL, time='00:05:10.5')
+
+    def test_XMLOutputContainsThumbnail(self, feed, itemWithThumbnail):
+        """ first output test: the thumbnail element must be in the output """
+        feed.items = [itemWithThumbnail]
+        output = feed.to_xml()
+        assert '<media:thumbnail' in output
+
+    def test_publishesCorrectly(self, feed, itemWithThumbnail):
+        """ the thumbnail element should be output with the desired argument order """
+        feed.items = [itemWithThumbnail]
+        output = feed.to_xml()
+
+        assert output.endswith(
+            '<media:thumbnail url="http://nowhere.org/img/hippo_tn.jpg" width="150" height="652" time="00:15:46"></media:thumbnail>' +
+            '</media:content>' +
+            '</item></channel></rss>'
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist=py26,py27,py34
+
+[testenv]
+deps=
+        pytest
+        PyRSS2Gen
+
+commands=py.test


### PR DESCRIPTION
I implemented support for the media:thumbnail element. And added tox configuration, because I am too lazy to test in three environments manually.

I have to confess one grave sin against the contributing guidelines: I tested with python 3.2, not 3.4.
